### PR TITLE
return paths in MyGet-Normalize-Paths

### DIFF
--- a/myget.include.ps1
+++ b/myget.include.ps1
@@ -853,6 +853,7 @@ function MyGet-Normalize-Paths {
         $i++;
     }
 
+	return $paths 
 }
 
 function MyGet-TargetFramework-To-Clr {


### PR DESCRIPTION
I had some issue with **MyGet-Normalize-Paths** because it wasn't returning anything. Return the array fixed this issue.
