### PR TITLE
Fix for #3 where MyGet-Build-Clean does not clean the specifiec folders

### DIFF
--- a/myget.include.ps1
+++ b/myget.include.ps1
@@ -987,11 +987,14 @@ function MyGet-Build-Clean {
     )
 
     MyGet-Write-Diagnostic "Build: Clean"
+    
+    $deleteFolders = $folders -split ","
 
-    Get-ChildItem $rootFolder -Include $folders -Recurse | ForEach-Object {
-       Remove-Item $_.fullname -Force -Recurse 
+    Foreach($deletePath in $deleteFolders) {
+        if (Test-Path "$rootFolder/$deletePath"){
+            Remove-Item -Recurse -Force "$rootFolder/$deletePath"
+        }
     }
-
 }
 
 function MyGet-Build-Bootstrap {


### PR DESCRIPTION
MyGet-Build-Clean did not delete folder contents due to invalid parameter passing to Get-ChildItem. To avoid introducing a breaking change in the function parameters, i string split the input parameter to create an array and loop through this array to delete. #3
